### PR TITLE
Better handling of application with no icon

### DIFF
--- a/classroom/assets/js/main/GroupAdminManager.js
+++ b/classroom/assets/js/main/GroupAdminManager.js
@@ -98,10 +98,10 @@ class GroupAdminManager {
                 let div_img = ""
                 if (element.hasOwnProperty('applications')) {
                     element.applications.forEach(element_2 => {
-                        if (element_2.image != null) {
-                            div_img += `<img src="assets/media/${element_2.image}" data-toggle="tooltip" alt="${element_2.name}" title="${element_2.name}" style="max-height: 24px;" class="mx-1">`;
+                        if (element_2.image != null && element_2.image != "") {
+                            div_img += `<img src="assets/plugins/images/${element_2.image}" data-toggle="tooltip" alt="${element_2.name}" title="${element_2.name}" style="max-height: 24px;" class="mx-1">`;
                         } else {
-                            div_img += `<img src="assets/media/nologo.jpg" data-toggle="tooltip" alt="${element_2.name}" title="${element_2.name}" style="max-height: 24px;" class="mx-1">`;
+                            div_img += `<img src="assets/media/no-app-icon.svg" data-toggle="tooltip" alt="${element_2.name}" title="${element_2.name}" style="max-height: 24px;" class="mx-1">`;
                         }
                     });
                 }
@@ -171,10 +171,10 @@ class GroupAdminManager {
                     let div_img = ""
                     if (element.hasOwnProperty('applicationsFromGroups')) {
                         element.applicationsFromGroups.forEach(element_2 => {
-                            if (element_2.image != null) {
-                                div_img += `<img src="assets/media/${element_2.image}" data-toggle="tooltip" alt="${element_2.name}" title="${element_2.name}" style="max-height: 24px;" class="mx-1">`;
+                            if (element_2.image != null && element_2.image != "") {
+                                div_img += `<img src="assets/plugins/images/${element_2.image}" data-toggle="tooltip" alt="${element_2.name}" title="${element_2.name}" style="max-height: 24px;" class="mx-1">`;
                             } else {
-                                div_img += `<img src="assets/media/nologo.jpg" data-toggle="tooltip" alt="${element_2.name}" title="${element_2.name}" style="max-height: 24px;" class="mx-1">`;
+                                div_img += `<img src="assets/media/no-app-icon.svg" data-toggle="tooltip" alt="${element_2.name}" title="${element_2.name}" style="max-height: 24px;" class="mx-1">`;
                             }
                         });
                     }
@@ -259,10 +259,10 @@ class GroupAdminManager {
                     let div_img = ""
                     if (element.hasOwnProperty('applicationsFromGroups')) {
                         element.applicationsFromGroups.forEach(element_2 => {
-                            if (element_2.image != null) {
-                                div_img += `<img src="assets/media/${element_2.image}" data-toggle="tooltip" alt="${element_2.name}" title="${element_2.name}" style="max-height: 24px;" class="mx-1">`;
+                            if (element_2.image != null && element_2.image != "") {
+                                div_img += `<img src="assets/plugins/images/${element_2.image}" data-toggle="tooltip" alt="${element_2.name}" title="${element_2.name}" style="max-height: 24px;" class="mx-1">`;
                             } else {
-                                div_img += `<img src="assets/media/nologo.jpg" data-toggle="tooltip" alt="${element_2.name}" title="${element_2.name}" style="max-height: 24px;" class="mx-1">`;
+                                div_img += `<img src="assets/media/no-app-icon.svg" data-toggle="tooltip" alt="${element_2.name}" title="${element_2.name}" style="max-height: 24px;" class="mx-1">`;
                             }
                         });
                     }

--- a/classroom/assets/js/main/ManagerManager.js
+++ b/classroom/assets/js/main/ManagerManager.js
@@ -842,10 +842,10 @@ class managerManager {
                     let div_img = ""
                     if (element.hasOwnProperty('applications')) {
                         element.applications.forEach(element_2 => {
-                            if (element_2.image != null) {
-                                div_img += `<img src="assets/media/${element_2.image}" data-toggle="tooltip" alt="${element_2.name}" title="${element_2.name}" style="max-height: 24px;" class="mx-1">`;
+                            if (element_2.image != null && element_2.image != "") {
+                                div_img += `<img src="assets/plugins/images/${element_2.image}" data-toggle="tooltip" alt="${element_2.name}" title="${element_2.name}" style="max-height: 24px;" class="mx-1">`;
                             } else {
-                                div_img += `<img src="assets/media/nologo.jpg" data-toggle="tooltip" alt="${element_2.name}" title="${element_2.name}" style="max-height: 24px;" class="mx-1">`;
+                                div_img += `<img src="assets/media/no-app-icon.svg" data-toggle="tooltip" alt="${element_2.name}" title="${element_2.name}" style="max-height: 24px;" class="mx-1">`;
                             }
                         });
                     }
@@ -943,10 +943,10 @@ class managerManager {
                     let div_img = ""
                     if (element.hasOwnProperty('applications')) {
                         element.applications.forEach(element_2 => {
-                            if (element_2.image != null) {
-                                div_img += `<img src="assets/media/${element_2.image}" data-toggle="tooltip" alt="${element_2.name}" title="${element_2.name}" style="max-height: 24px;" class="mx-1">`;
+                            if (element_2.image != null && element_2.image != "") {
+                                div_img += `<img src="assets/plugins/images/${element_2.image}" data-toggle="tooltip" alt="${element_2.name}" title="${element_2.name}" style="max-height: 24px;" class="mx-1">`;
                             } else {
-                                div_img += `<img src="assets/media/nologo.jpg" data-toggle="tooltip" alt="${element_2.name}" title="${element_2.name}" style="max-height: 24px;" class="mx-1">`;
+                                div_img += `<img src="assets/media/no-app-icon.svg" data-toggle="tooltip" alt="${element_2.name}" title="${element_2.name}" style="max-height: 24px;" class="mx-1">`;
                             }
                         });
                     }
@@ -1064,10 +1064,10 @@ class managerManager {
                 let div_img = ""
                 if (element.hasOwnProperty('applications')) {
                     element.applications.forEach(element_2 => {
-                        if (element_2.image != null) {
-                            div_img += `<img src="assets/media/${element_2.image}" data-toggle="tooltip" alt="${element_2.name}" title="${element_2.name}" style="max-height: 24px;" class="mx-1">`;
+                        if (element_2.image != null && element_2.image != "") {
+                            div_img += `<img src="assets/plugins/images/${element_2.image}" data-toggle="tooltip" alt="${element_2.name}" title="${element_2.name}" style="max-height: 24px;" class="mx-1">`;
                         } else {
-                            div_img += `<img src="assets/media/nologo.jpg" data-toggle="tooltip" alt="${element_2.name}" title="${element_2.name}" style="max-height: 24px;" class="mx-1">`;
+                            div_img += `<img src="assets/media/no-app-icon.svg" data-toggle="tooltip" alt="${element_2.name}" title="${element_2.name}" style="max-height: 24px;" class="mx-1">`;
                         }
                     });
                 }
@@ -1126,10 +1126,10 @@ class managerManager {
                     let div_img = ""
                     if (element.hasOwnProperty('applications')) {
                         element.applications.forEach(element_2 => {
-                            if (element_2.image != null) {
-                                div_img += `<img src="assets/media/${element_2.image}" data-toggle="tooltip" alt="${element_2.name}" title="${element_2.name}" style="max-height: 24px;" class="mx-1">`;
+                            if (element_2.image != null && element_2.image != "") {
+                                div_img += `<img src="assets/plugins/images/${element_2.image}" data-toggle="tooltip" alt="${element_2.name}" title="${element_2.name}" style="max-height: 24px;" class="mx-1">`;
                             } else {
-                                div_img += `<img src="assets/media/nologo.jpg" data-toggle="tooltip" alt="${element_2.name}" title="${element_2.name}" style="max-height: 24px;" class="mx-1">`;
+                                div_img += `<img src="assets/media/no-app-icon.svg" data-toggle="tooltip" alt="${element_2.name}" title="${element_2.name}" style="max-height: 24px;" class="mx-1">`;
                             }
                         });
                     }

--- a/classroom/assets/media/no-app-icon.svg
+++ b/classroom/assets/media/no-app-icon.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 24.3.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 21 21" style="enable-background:new 0 0 21 21;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;stroke:#666666;stroke-linecap:round;stroke-linejoin:round;}
+	.st1{fill-rule:evenodd;clip-rule:evenodd;fill:#666666;stroke:#666666;stroke-linecap:round;stroke-linejoin:round;}
+</style>
+<g transform="translate(3 3)">
+	<path class="st0" d="M0.5-2.3h14c1.5,0,2.8,1.3,2.8,2.8v14c0,1.5-1.3,2.8-2.8,2.8h-14c-1.5,0-2.8-1.3-2.8-2.8v-14
+		C-2.3-1.1-1.1-2.3,0.5-2.3z"/>
+	<path class="st1" d="M0.5,0.5h14c1.5,0,2.8,1.3,2.8,2.8V0.5c0-1.4-1.3-2.8-2.8-2.8h-14c-1.5,0-2.8,1.4-2.8,2.8v2.8
+		C-2.3,1.7-1.1,0.5,0.5,0.5z"/>
+	<path class="st0" d="M3.3,7.5h1.4"/>
+	<path class="st0" d="M3.3,4.7h5.6"/>
+	<path class="st0" d="M3.3,10.3h8.4"/>
+	<path class="st0" d="M3.3,13.1h5.6"/>
+</g>
+</svg>


### PR DESCRIPTION
This PR adds a new icon for any application with a missing icon. (for light/dark theme)
Alongside this, this also matches for an empty string as an app icon link so it better matches missing icons.
Icons are now searched in the `assets/plugins/images/` folder as they are going to be added via plugins.

![image](https://user-images.githubusercontent.com/50020222/143284215-889f90d0-8f83-48da-a1e9-920e87e1a6dc.png)
